### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+venv/
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Install Python dependencies first
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+CMD ["python", "model.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+torch
+transformers
+huggingface-hub
+tiktoken


### PR DESCRIPTION
## Summary
- add slim Python 3.10 Dockerfile
- ignore development artifacts with `.dockerignore`
- specify Python package requirements

## Testing
- `python -m py_compile model.py util.py`
- `docker build -t qwen3-boilerplate .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685aea32a474833190802d57d2604364