### PR TITLE
Add config defaults and unit tests

### DIFF
--- a/qwen3/model.py
+++ b/qwen3/model.py
@@ -129,9 +129,13 @@ class Qwen3Config(PretrainedConfig):
         n_layer: int = 32,
         n_head: int = 32,
         n_embd: int = 4096,
-        intermediate_size: int = 22016, # From the original model config
+        intermediate_size: int = 22016,  # From the original model config
         rope_theta: float = 10000.0,
-        **kwargs
+        use_cache: bool = True,
+        use_return_dict: bool = True,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        **kwargs,
     ):
         self.vocab_size = vocab_size
         self.context_len = context_len
@@ -141,6 +145,11 @@ class Qwen3Config(PretrainedConfig):
         self.intermediate_size = intermediate_size
         self.rope_theta = rope_theta
 
+        # Cache and output settings used in the model forward pass
+        self.use_cache = use_cache
+        self.output_attentions = output_attentions
+        self.output_hidden_states = output_hidden_states
+
         # The Qwen model architecture supports Grouped-Query Attention (GQA) where
         # multiple query heads share key/value heads for efficiency. However, this
         # educational implementation uses Multi-Head Attention (MHA) for simplicity,
@@ -148,7 +157,12 @@ class Qwen3Config(PretrainedConfig):
         # For true GQA implementation, you would set n_kv_head < n_head.
         self.n_kv_head = n_head
 
-        super().__init__(**kwargs)
+        super().__init__(
+            return_dict=use_return_dict,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            **kwargs,
+        )
 
 
 # =============================================================================

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,96 @@
+import torch
+
+from qwen3.model import (
+    RMSNorm,
+    RotaryEmbedding,
+    apply_rotary_emb,
+    Qwen3Attention,
+    Qwen3MLP,
+    Qwen3Block,
+    Qwen3ForCausalLM,
+    Qwen3Config,
+)
+
+
+def tiny_config(**kwargs):
+    defaults = dict(
+        vocab_size=32,
+        context_len=16,
+        n_layer=2,
+        n_head=2,
+        n_embd=8,
+        intermediate_size=16,
+    )
+    defaults.update(kwargs)
+    return Qwen3Config(**defaults)
+
+
+def test_config_defaults():
+    cfg = tiny_config()
+    assert cfg.use_cache is True
+    assert cfg.use_return_dict is True
+    assert cfg.output_attentions is False
+    assert cfg.output_hidden_states is False
+
+
+def test_rmsnorm_basic():
+    torch.manual_seed(0)
+    x = torch.randn(2, 3, 8)
+    norm = RMSNorm(8)
+    norm.weight.data.fill_(1.0)
+    out = norm(x)
+    rms = x.pow(2).mean(-1, keepdim=True)
+    expected = x / torch.sqrt(rms + norm.eps)
+    assert torch.allclose(out, expected, atol=1e-6)
+
+
+def test_rotary_embedding_shape():
+    x = torch.randn(1, 4, 2, 4)
+    rope = RotaryEmbedding(dim=4, max_seq_len=10)
+    freqs = rope(x)
+    out = apply_rotary_emb(x, freqs)
+    assert out.shape == x.shape
+
+
+def test_attention_cache():
+    cfg = tiny_config()
+    attn = Qwen3Attention(cfg)
+    x = torch.randn(1, 3, cfg.n_embd)
+    out, _, pkv = attn(x, use_cache=True)
+    assert out.shape == (1, 3, cfg.n_embd)
+    assert pkv[0].shape[:3] == (1, 3, cfg.n_head)
+    x2 = torch.randn(1, 2, cfg.n_embd)
+    _, _, pkv2 = attn(x2, past_key_value=pkv, use_cache=True)
+    assert pkv2[0].shape[1] == 5
+
+
+def test_mlp_shape():
+    cfg = tiny_config()
+    mlp = Qwen3MLP(cfg)
+    x = torch.randn(2, 4, cfg.n_embd)
+    out = mlp(x)
+    assert out.shape == x.shape
+
+
+def test_block_shape():
+    cfg = tiny_config()
+    block = Qwen3Block(cfg)
+    x = torch.randn(1, 5, cfg.n_embd)
+    out, _, _ = block(x)
+    assert out.shape == x.shape
+
+
+def test_model_forward():
+    cfg = tiny_config()
+    model = Qwen3ForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (1, 4))
+    outputs = model(input_ids)
+    assert outputs.logits.shape == (1, 4, cfg.vocab_size)
+
+
+def test_model_loss():
+    cfg = tiny_config()
+    model = Qwen3ForCausalLM(cfg)
+    input_ids = torch.randint(0, cfg.vocab_size, (1, 4))
+    outputs = model(input_ids, labels=input_ids)
+    assert outputs.loss is not None


### PR DESCRIPTION
## Summary
- expose cache and return dict settings in `Qwen3Config`
- add unit test to verify config defaults
- ensure model forward works with new config settings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af22eb8c88331bca987a153540814